### PR TITLE
8.11.2 release

### DIFF
--- a/old-solr-versions
+++ b/old-solr-versions
@@ -1,14 +1,14 @@
 
-Tags: 8.11.1, 8.11, 8
+Tags: 8.11.2, 8.11, 8
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/docker-solr/docker-solr.git
 GitFetch: refs/heads/master
-GitCommit: b30202ad6e336baf108c7c42222df723ba338010
+GitCommit: 970bb718583d14f6f1300f6fd261f01ddcf757c8
 Directory: 8.11
 
-Tags: 8.11.1-slim, 8.11-slim, 8-slim
+Tags: 8.11.2-slim, 8.11-slim, 8-slim
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/docker-solr/docker-solr.git
 GitFetch: refs/heads/master
-GitCommit: b30202ad6e336baf108c7c42222df723ba338010
+GitCommit: 970bb718583d14f6f1300f6fd261f01ddcf757c8
 Directory: 8.11/slim


### PR DESCRIPTION
https://solr.apache.org/news.html#apache-solrtm-8112-available

https://github.com/docker-solr/docker-solr/pull/426