### PR TITLE
Dockerfile workaround to avoid crashes for SOLR 9.0.0 on JDK17

### DIFF
--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -131,6 +131,9 @@ RUN set -ex; \
     apt-get -y install acl dirmngr lsof procps wget netcat gosu tini jattach; \
     rm -rf /var/lib/apt/lists/*;
 
+# Workaround for JDK17 JIT compiler bug https://bugs.openjdk.org/browse/JDK-8285835)
+ARG SOLR_OPTS="-XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put"
+
 VOLUME /var/solr
 EXPOSE 8983
 WORKDIR /opt/solr

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -131,7 +131,7 @@ RUN set -ex; \
     apt-get -y install acl dirmngr lsof procps wget netcat gosu tini jattach; \
     rm -rf /var/lib/apt/lists/*;
 
-# Workaround for JDK17 JIT compiler bug https://bugs.openjdk.org/browse/JDK-8285835)
+# Workaround for JDK17 JIT compiler bug https://bugs.openjdk.org/browse/JDK-8285835
 ARG SOLR_OPTS="-XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put"
 
 VOLUME /var/solr

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -131,13 +131,11 @@ RUN set -ex; \
     apt-get -y install acl dirmngr lsof procps wget netcat gosu tini jattach; \
     rm -rf /var/lib/apt/lists/*;
 
-# Workaround for JDK17 JIT compiler bug https://bugs.openjdk.org/browse/JDK-8285835
-ARG SOLR_OPTS="-XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put"
-
 VOLUME /var/solr
 EXPOSE 8983
 WORKDIR /opt/solr
 USER $SOLR_USER
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr-foreground"]
+# TODO: Workaround for JDK17+ JIT compiler bug https://bugs.openjdk.org/browse/JDK-8285835)
+CMD ["solr-foreground", "-a", "-XX:CompileCommand=exclude,com.github.benmanes.caffeine.cache.BoundedLocalCache::put"]


### PR DESCRIPTION
This is a less intrusive solution to JIT crash for JDK 17 than downgrading to JRE11 (#10).

Using `SOLR_OPTS` will work for most users, except those who have passed in a custom `SOLR_OPTS` environment to the docker container on startup, that will overwrite this default. If anyone sees a more robust way of injecting this JVM flag without patching `bin/solr`, then speak out.