### PR TITLE
Replace openjdk:11-jre with eclipse-temurin:11-jre for 8.11 images

### DIFF
--- a/8.11-slim/Dockerfile
+++ b/8.11-slim/Dockerfile
@@ -1,5 +1,5 @@
-
-FROM openjdk:11-jre-slim
+# Patched 2022-10-20 to change from openjdk:11-jre-slim to eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre
 
 LABEL maintainer="The Apache Lucene/Solr Project"
 LABEL repository="https://github.com/docker-solr/docker-solr"

--- a/8.11/Dockerfile
+++ b/8.11/Dockerfile
@@ -1,5 +1,5 @@
-
-FROM openjdk:11-jre
+# Patched 2022-10-20 to change from openjdk:11-jre to eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre
 
 LABEL maintainer="The Apache Lucene/Solr Project"
 LABEL repository="https://github.com/docker-solr/docker-solr"


### PR DESCRIPTION
`openjdk:11-jre` is removed from official images, so to continue using it as FROM for Solr 8.11 we need to change, error msg from generate-stackbrew here https://github.com/apache/solr-docker/actions/runs/3289554711/jobs/5421229769

```[1](https://github.com/apache/solr-docker/actions/runs/3289554711/jobs/5421229769#step:6:1)
Run ./generate-stackbrew-library.sh > official-images/library/solr
  ./generate-stackbrew-library.sh > official-images/library/solr
  shell: /usr/bin/bash -e {0}
failed fetching repo "https://github.com/docker-library/official-images/raw/master/library/openjdk:11-jre"
tag not found in manifest for "openjdk": "11-jre"
./generate-stackbrew-library.sh: line 11[3](https://github.com/apache/solr-docker/actions/runs/3289554711/jobs/5421229769#step:6:3): parentRepoToArches[$variantParent]: unbound variable
Error: Process completed with exit code 1.
```