### PR TITLE
Use focal variant of eclipse-temurin images

### DIFF
--- a/8.11-slim/Dockerfile
+++ b/8.11-slim/Dockerfile
@@ -1,5 +1,6 @@
+ARG VARIANT
 # Patched 2022-10-20 to change from openjdk:11-jre-slim to eclipse-temurin:11-jre
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre${VARIANT:-}
 
 LABEL maintainer="The Apache Lucene/Solr Project"
 LABEL repository="https://github.com/docker-solr/docker-solr"

--- a/8.11-slim/Dockerfile
+++ b/8.11-slim/Dockerfile
@@ -1,6 +1,6 @@
-ARG VARIANT
 # Patched 2022-10-20 to change from openjdk:11-jre-slim to eclipse-temurin:11-jre
-FROM eclipse-temurin:11-jre${VARIANT:-}
+# Patched 2022-10-21 to use eclipse-temurin:11-jre-focal which used Ubuntu 20.04, compatible with Docker client < 20.10.16
+FROM eclipse-temurin:11-jre-focal
 
 LABEL maintainer="The Apache Lucene/Solr Project"
 LABEL repository="https://github.com/docker-solr/docker-solr"

--- a/8.11/Dockerfile
+++ b/8.11/Dockerfile
@@ -1,5 +1,6 @@
+ARG VARIANT
 # Patched 2022-10-20 to change from openjdk:11-jre to eclipse-temurin:11-jre
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:11-jre${VARIANT:-}
 
 LABEL maintainer="The Apache Lucene/Solr Project"
 LABEL repository="https://github.com/docker-solr/docker-solr"

--- a/8.11/Dockerfile
+++ b/8.11/Dockerfile
@@ -1,6 +1,6 @@
-ARG VARIANT
 # Patched 2022-10-20 to change from openjdk:11-jre to eclipse-temurin:11-jre
-FROM eclipse-temurin:11-jre${VARIANT:-}
+# Patched 2022-10-21 to use eclipse-temurin:11-jre-focal which used Ubuntu 20.04, compatible with Docker client < 20.10.16
+FROM eclipse-temurin:11-jre-focal
 
 LABEL maintainer="The Apache Lucene/Solr Project"
 LABEL repository="https://github.com/docker-solr/docker-solr"

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-FROM eclipse-temurin:17-jre
+ARG VARIANT
+FROM eclipse-temurin:17-jre${VARIANT:-}
 
 # TODO: remove things that exist solely for downstream specialization since Dockerfile.local now exists for that
 

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VARIANT
-FROM eclipse-temurin:17-jre${VARIANT:-}
+# Patched 2022-10-21 to use eclipse-temurin:11-jre-focal which used Ubuntu 20.04, compatible with Docker client  < 20.10.16
+FROM eclipse-temurin:17-jre-focal
 
 # TODO: remove things that exist solely for downstream specialization since Dockerfile.local now exists for that
 


### PR DESCRIPTION
focal variant is required to run the image with Docker < 20.10.16