### PR TITLE
Chore: reduce attack surface and size for Docker image

### DIFF
--- a/8.11/Dockerfile
+++ b/8.11/Dockerfile
@@ -18,7 +18,7 @@ ARG SOLR_DOWNLOAD_SERVER
 
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install acl dirmngr gpg lsof procps wget netcat gosu tini; \
+  apt-get -y --no-install-recommends install acl dirmngr gpg lsof procps wget netcat gosu tini; \
   rm -rf /var/lib/apt/lists/*; \
   cd /usr/local/bin; wget -nv https://github.com/apangin/jattach/releases/download/v2.0/jattach; chmod 755 jattach; \
   echo >jattach.sha512 "a19e774600d6aa844bceb2189285848127a70130a69fb1840c10367f3360972c733b3f09e60e9672d387e2d48c750ab56acfe8f80f7c6af76f5d1123e5ad7222  jattach"; \


### PR DESCRIPTION
Hi,

This pull request includes a small improvement for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

In detail:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.